### PR TITLE
Use .balign for alignment directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ kanios is a toy operating system.
 - `qemu-system-riscv64`
 - `riscv64-unknown-elf-gcc`
 - `cargo`
+- `rustc` for riscv64-unknown-none-elf
+  - `rustup target add riscv-64-unknown-none-elf`, see [the section](https://rust-lang.github.io/rustup/cross-compilation.html)
 
 ### Build and Run
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -41,7 +41,7 @@ pub struct TrapFrame {
 
 global_asm!(
     r#"
-.align 8
+.balign 8
 .global kernel_entry
 kernel_entry:
     csrrw sp, sscratch, sp
@@ -142,7 +142,7 @@ fn handle_trap(f: *mut TrapFrame) {
 
 global_asm!(
     r#"
-.align 8
+.balign 8
 .global user_entry
 user_entry:
     addi sp, sp, -8 * 2

--- a/src/process.rs
+++ b/src/process.rs
@@ -138,7 +138,7 @@ static mut PROCS: [Process; PROCS_MAX] = [Process::new(); PROCS_MAX];
 
 global_asm!(
     r#"
-.align 8
+.balign 8
 .global switch_context
 switch_context:
     addi sp, sp, -13 * 8


### PR DESCRIPTION
w.r.t. https://opentitan.org/book/doc/contributing/style_guides/asm_coding_style.html#alignment-directives

And .align is power-of-two to align to on LLVM assembler, same as [gcc](https://sourceware.org/binutils/docs/as/RISC_002dV_002dDirectives.html).